### PR TITLE
version: bump to 3.1.4-palantir

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -26,7 +26,7 @@ import (
 var (
 	// MinClusterVersion is the min cluster version this etcd binary is compatible with.
 	MinClusterVersion = "3.0.0"
-	Version           = "3.1.4+git"
+	Version           = "3.1.4-palantir"
 	APIVersion        = "unknown"
 
 	// Git SHA Value will be set during build


### PR DESCRIPTION
etcd 3.1.4-palantir is meant for internal testing and potentially a release to tide over users who already upgraded to 3.1.x and cannot downgrade or wait for 3.1.5.