### PR TITLE
Remove backend quota cap

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -49,7 +49,7 @@ const (
 	DefaultQuotaBytes = int64(2 * 1024 * 1024 * 1024) // 2GB
 	// MaxQuotaBytes is the maximum number of bytes suggested for a backend
 	// quota. A larger quota may lead to degraded performance.
-	MaxQuotaBytes = int64(8 * 1024 * 1024 * 1024) // 8GB
+	MaxQuotaBytes = math.MaxInt64 // no limit
 )
 
 type Backend interface {


### PR DESCRIPTION
The recovery case is very infreqeuent and we are okay with longer mean time to
recovery on a per-configuration basis as a means to break glass and store more
data in etcd.

See original issue for more details: https://github.com/coreos/etcd/issues/7045