### PR TITLE
Fix missing import

### DIFF
--- a/mvcc/backend/backend.go
+++ b/mvcc/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"hash/crc32"
 	"io"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"


### PR DESCRIPTION
Missed the math import when introducing math.MaxInt64.