### PR TITLE
Increase max request size by order of magnitude

### DIFF
--- a/etcdserver/v3_server.go
+++ b/etcdserver/v3_server.go
@@ -36,7 +36,7 @@ const (
 	// TODO: make this a flag? But we probably do not want to
 	// accept large request which might block raft stream. User
 	// specify a large value might end up with shooting in the foot.
-	maxRequestBytes = 1.5 * 1024 * 1024
+	maxRequestBytes = 15 * 1024 * 1024
 
 	// In the health case, there might be a small gap (10s of entries) between
 	// the applied index and committed index.


### PR DESCRIPTION
We exceeded this request limit and need time to vet the 3.1 -> 3.2
migration process before we take v3.2 where this cap is made
configurable.